### PR TITLE
revisit fip attach/detach

### DIFF
--- a/ecloud/resource_floatingip.go
+++ b/ecloud/resource_floatingip.go
@@ -156,24 +156,6 @@ func resourceFloatingIPRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ip_address", fip.IPAddress)
 	d.Set("availability_zone_id", fip.AvailabilityZoneID)
 
-	resourceID := fip.ResourceID
-
-	// Handle scenario where defined resource_id is a NIC, however API is returning corresponding DHCP IP address ID
-	// for that NIC. We override the resource_id in the state with the NIC ID rather than the DHCP IP address ID
-	if strings.HasPrefix(d.Get("resource_id").(string), "nic-") && strings.HasPrefix(resourceID, "ip-") {
-		nicID := d.Get("resource_id").(string)
-		nicDHCPAddress, err := getNICDHCPAddress(service, nicID)
-		if err != nil {
-			return fmt.Errorf("Error retrieving DHCP IP address for NIC with ID [%s]: %s", resourceID, err)
-		}
-
-		if nicDHCPAddress.ID == resourceID {
-			resourceID = nicID
-		}
-	}
-
-	d.Set("resource_id", resourceID)
-
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 	github.com/stretchr/testify v1.7.0
-	github.com/ukfast/sdk-go v1.6.2
+	github.com/ukfast/sdk-go v1.6.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ukfast/go-durationstring v1.1.0 h1:Ki0ubc5jqSt7XuAs+gkPNpHYolIwbcsRW4LS239tIHA=
 github.com/ukfast/go-durationstring v1.1.0/go.mod h1:Ci81n51kfxlKUIaLY9cINIKRO94VTqV+iCGbOMTb0V8=
-github.com/ukfast/sdk-go v1.6.2 h1:7QJJyrTTCM/chZW/lA2wLgokHjKopBBWuGdYWTFexas=
-github.com/ukfast/sdk-go v1.6.2/go.mod h1:NynAokVgvxZNUmUySgSIckA8Kcc43urFM2F2qHFq13s=
+github.com/ukfast/sdk-go v1.6.3 h1:Pz3ufkHpwyTv+MRXo2/7IE4L/NDX5Kys5nF8+UxJ128=
+github.com/ukfast/sdk-go v1.6.3/go.mod h1:NynAokVgvxZNUmUySgSIckA8Kcc43urFM2F2qHFq13s=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
- support FIP assignment on instance resources at creation by specifying a `floating_ip_id` on the resource
- support FIP assignment on VPN Endpoint resources at creation by specifying a `floating_ip_id` on the resource
- clean up any managed FIPs on the VPN Endpoint resource at deletion time if a `floating_ip_id` is NOT specified